### PR TITLE
English fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,7 +1,7 @@
 {
     "TopPagesByActions": {
         "SettingsIntroduction": "Here you can specify the settings for this plugin.",
-        "SettingsRefreshInterval": "Refresh interval",
+        "SettingsRefreshInterval": "Refresh interval (seconds)",
         "SettingsRefreshIntervalDescription": "Defines how often the widget should be updated.",
         "SettingsRefreshIntervalHelp": "Enter a number which is >= 1",
         "SettingsNumber": "Number of entries to show",
@@ -10,6 +10,6 @@
         "TableHeaderActions": "Actions",
         "TableHeaderPage": "Page",
         "TableHeaderEngagedTime": "Engaged Time",
-        "WidgetName": "Bestperforming pages"
+        "WidgetName": "Top pages"
     }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,7 +9,7 @@
         "SettingsNumberHelp": "Enter a number which is >= 10 and <= 30",
         "TableHeaderActions": "Actions",
         "TableHeaderPage": "Page",
-        "TableHeaderEngagedTime": "Engaged Time",
+        "TableHeaderEngagedTime": "Avg Engaged Time",
         "WidgetName": "Top pages"
     }
 }


### PR DESCRIPTION
Hello,

"Bestperforming" is not a proper English word. It could be "Best performing" with a space, but I'm changing it to just "Top", which is simpler/clearer and matches the name of the plugin.

Also adding a unit " (seconds)" to the refresh interval setting so the user knows what to enter.

And adding "Avg" to the "Engaged Time" header to make it clear that it is the average time per action, rather than the total across actions (which would be another reasonable way to measure top performing pages).

Thanks.